### PR TITLE
build: only run coverage over cloudconnectlib folder

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Install Code
         run: source $HOME/.poetry/env; poetry install
       - name: Run Pytest with coverage
-        run: source $HOME/.poetry/env; poetry run pytest --cov=./ --cov-report=xml --junitxml=test-results/junit.xml test/unit
+        run: source $HOME/.poetry/env; poetry run pytest --cov=./cloudconnectlib --cov-report=xml --junitxml=test-results/junit.xml test/unit
         env:
           SPLUNK_HOME: "/opt/splunk"
       - name: Upload coverage to Codecov


### PR DESCRIPTION
Otherwise, it is going to report coverage for the whole project: `test`, .`venv` folder etc.

Coverage is failing because of the bug on their side: https://github.com/codecov/codecov-action/issues/437