### PR TITLE
ci: allow dependabot[bot] in CLA and COC

### DIFF
--- a/.github/workflows/agreements.yaml
+++ b/.github/workflows/agreements.yaml
@@ -22,7 +22,7 @@ jobs:
           path-to-document: "https://github.com/splunk/cla-agreement/blob/main/CLA.md" # e.g. a CLA or a DCO document
           # branch should not be protected
           branch: "main"
-          allowlist: dependabot
+          allowlist: dependabot[bot]
           #below are the optional inputs - If the optional inputs are not given, then default values will be taken
           remote-organization-name: splunk
           remote-repository-name: cla-agreement
@@ -47,7 +47,7 @@ jobs:
           path-to-document: "https://github.com/splunk/cla-agreement/blob/main/CODE_OF_CONDUCT.md" # e.g. a COC or a DCO document
           # branch should not be protected
           branch: "main"
-          allowlist: dependabot
+          allowlist: dependabot[bot]
           #below are the optional inputs - If the optional inputs are not given, then default values will be taken
           remote-organization-name: splunk
           remote-repository-name: cla-agreement


### PR DESCRIPTION
The same as in https://github.com/splunk/addonfactory-ucc-generator/blob/main/.github/workflows/agreements.yaml#L25-L50.