### PR TITLE
fix!: remove regex_not_match function from cloudconnect library

### DIFF
--- a/cloudconnectlib/core/ext.py
+++ b/cloudconnectlib/core/ext.py
@@ -65,18 +65,6 @@ def regex_match(pattern, source, flags=0):
     return False
 
 
-def regex_not_match(pattern, source, flags=0):
-    """
-    Determine whether a string is not match a regex pattern.
-
-    :param pattern: regex expression
-    :param source: candidate to match regex
-    :param flags: flags for regex match
-    :return: `True` if candidate not match pattern else `False`
-    """
-    return not regex_match(pattern, source, flags)
-
-
 def json_path(source, json_path_expr):
     """ Extract value from string with JSONPATH expression.
     :param json_path_expr: JSONPATH expression
@@ -387,7 +375,6 @@ _extension_functions = {
     'exit_job_if_true': exit_job_if_true,
     'is_true': is_true,
     'regex_match': regex_match,
-    'regex_not_match': regex_not_match,
     'regex_search': regex_search,
     'set_var': set_var,
     'splunk_xml': splunk_xml,

--- a/test/unit/test_ext.py
+++ b/test/unit/test_ext.py
@@ -23,7 +23,6 @@ from cloudconnectlib.core.ext import (
     is_true,
     lookup_method,
     regex_match,
-    regex_not_match,
     regex_search,
     std_output,
     splunk_xml,
@@ -42,11 +41,6 @@ def test_regex_match():
     assert regex_match('^[A-Za-z0-9]+', '123456abcdefg')
     assert regex_match('^$', '')
     assert regex_match('', 'abcd')
-
-
-def test_regex_not_match():
-    assert regex_not_match('\bclass\b', 'no class at all')
-    assert regex_not_match('^[A-Z]+', '123456')
 
 
 def test_splunk_xml():


### PR DESCRIPTION
This is a strictly opposite function to regex_match.

This function is not used in the cloudconnect library code anywhere.
There are also no usage in the add-ons we have.