### PR TITLE
ci: multiple updates to the pipeline

### DIFF
--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -1,10 +1,6 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
-# Controls when the action will run.
 on:
-  # Triggers the workflow on push or pull request events but only for the main branch
   push:
     branches:
       - "main"
@@ -17,7 +13,6 @@ on:
 jobs:
   compliance-dependencies:
     name: Compliance Dependencies
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
     steps:
@@ -66,7 +61,7 @@ jobs:
         with:
           python-version: 3.7
       - name: Install Poetry
-        run: curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
+        run: curl -sSL https://install.python-poetry.org | python3 -
       - name: Install Splunk
         run: |
           pip install --user git+https://github.com/pixelb/crudini
@@ -89,9 +84,9 @@ jobs:
         env:
           SPLUNK_VERSION: 8.2
       - name: Install Code
-        run: source $HOME/.poetry/env; poetry install
+        run: poetry install
       - name: Run Pytest with coverage
-        run: source $HOME/.poetry/env; poetry run pytest --cov=./cloudconnectlib --cov-report=xml --junitxml=test-results/junit.xml test/unit
+        run: poetry run pytest --cov=./cloudconnectlib --cov-report=xml --junitxml=test-results/junit.xml test/unit
         env:
           SPLUNK_HOME: "/opt/splunk"
       - name: Upload coverage to Codecov
@@ -141,22 +136,7 @@ jobs:
         id: semgrep
         uses: returntocorp/semgrep-action@v1
         with:
-          config: p/r2c
-  snyk:
-    name: security-vuln-snyk
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Run Snyk to check for vulnerabilities
-        uses: snyk/actions/python-3.8@master
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          args: --sarif-file-output=snyk.sarif
-      - name: Upload result to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v1
-        with:
-          sarif_file: snyk.sarif
+          publishToken: ${{ secrets.SEMGREP_PUBLISH_TOKEN }}
   build:
     name: Build Release
     needs:
@@ -180,9 +160,9 @@ jobs:
         with:
           python-version: "3.7"
       - name: Install Poetry
-        run: curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
-      - name: Install Code
-        run: source $HOME/.poetry/env; poetry build
+        run: | 
+          curl -sSL https://install.python-poetry.org | python3 -
+          poetry build
       - uses: actions/download-artifact@v2
         with:
           name: analysis-reports


### PR DESCRIPTION
From `poetry` [README](https://github.com/python-poetry/poetry#installation):

Warning: The previous get-poetry.py installer is now deprecated, if you are currently using it you should migrate to the new, supported, install-poetry.py installer.

Also, removed `snyk` and updated configuration for `semgrep`.