### PR TITLE
ci: update semantic version and remove node 14 workaround

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,10 @@
-# Basic dependabot.yml file with
-# minimum configuration for two package managers
-
 version: 2
 updates:
-  # Enable version updates for npm
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
-
-  # Enable version updates for Docker
   - package-ecosystem: "pip"
-    # Look for a `Dockerfile` in the `root` directory
     directory: "/"
-    # Check for updates once a week
     schedule:
       interval: "daily"

--- a/.github/workflows/build-test-release.yml
+++ b/.github/workflows/build-test-release.yml
@@ -152,9 +152,6 @@ jobs:
           #Very Important semantic-release won't trigger a tagged
           #build if this is not set false
           persist-credentials: false
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '14'
       - name: Setup python
         uses: actions/setup-python@v2
         with:
@@ -170,9 +167,9 @@ jobs:
       - name: Update Notices
         run: cp -f /tmp/analysis-reports/NOTICE_summary NOTICE
       - name: Semantic Release
-        uses: cycjimmy/semantic-release-action@v2.6.0
+        uses: cycjimmy/semantic-release-action@v3.0.0
         with:
-          semantic_version: 17
+          semantic_version: 19.0.2
           extra_plugins: |
             @semantic-release/exec
             @semantic-release/git


### PR DESCRIPTION
- ci: update semantic version and remove node 14 workaround
- chore: clean up dependabot conf file
