### PR TITLE
fix(CODE): ADDON-58725: Removed the unsecured reconnection request

### DIFF
--- a/cloudconnectlib/core/http.py
+++ b/cloudconnectlib/core/http.py
@@ -221,25 +221,13 @@ class HttpClient:
                 verify=self.requests_verify,
             )
         except SSLHandshakeError:
-            _logger.warning(
+            _logger.error(
                 "[SSL: CERTIFICATE_VERIFY_FAILED] certificate verification failed. "
                 "The certificate of the https server [%s] is not trusted, "
-                "this add-on will proceed to connect with this certificate. "
                 "You may need to check the certificate and "
                 "refer to the documentation and add it to the trust list. %s",
                 uri,
                 traceback.format_exc(),
-            )
-
-            self._connection = self._build_http_connection(
-                proxy_info=proxy_info, disable_ssl_cert_validation=True
-            )
-            return self._connection.request(
-                url=uri,
-                data=body,
-                method=method,
-                headers=headers,
-                timeout=defaults.timeout,
             )
 
     def _retry_send_request_if_needed(self, uri, method="GET", headers=None, body=None):

--- a/cloudconnectlib/core/http.py
+++ b/cloudconnectlib/core/http.py
@@ -240,6 +240,8 @@ class HttpClient:
                 resp = self._send_internal(
                     uri=uri, body=body, method=method, headers=headers
                 )
+                if not resp:
+                    raise SSLHandshakeError
                 content = resp.content
                 response = resp
             except Exception as err:


### PR DESCRIPTION
Main JIRA: https://splunk.atlassian.net/browse/ADDON-58725
Add-on JIRA: https://splunk.atlassian.net/browse/ADDON-59035

- If an HTTPS connection fails due to trust, previously it gave a warning but again it tried to make a connection by disabling the ssl certificate validation (disable_ssl_cert_validation=True)
- Basically, it allowed an unsecure connection to a possible unsecured URL.
- After making the changes, we will now raise an ERROR instead of a warning and will exit the flow without trying to reconnect.

Unit Tested the code with Salesforce Add-on. 
- It is working as expected. 
- Once the request is failed for the first time, it won't make another request by disabling the SSL verification.
- Also, the working of the modinputs are working as expected.