### PR TITLE
fix(CODE): Replaced the old incorrect exception with requests libs exception

### DIFF
--- a/cloudconnectlib/__init__.py
+++ b/cloudconnectlib/__init__.py
@@ -17,4 +17,4 @@
 Cloud Connect library
 """
 
-__version__ = "3.1.0"
+__version__ = "3.1.3"

--- a/cloudconnectlib/core/http.py
+++ b/cloudconnectlib/core/http.py
@@ -241,12 +241,12 @@ class HttpClient:
                     uri,
                     traceback.format_exc(),
                 )
-                raise HTTPError("HTTP Error %s" % str(err))
+                raise HTTPError(f"HTTP Error {err}") from err
             except Exception as err:
                 _logger.exception(
                     "Could not send request url=%s method=%s", uri, method
                 )
-                raise HTTPError("HTTP Error %s" % str(err))
+                raise HTTPError(f"HTTP Error {err}") from err
 
             status = resp.status_code
 

--- a/cloudconnectlib/core/http.py
+++ b/cloudconnectlib/core/http.py
@@ -208,9 +208,8 @@ class HttpClient:
             self._proxy_info = proxy_info
         self._url_preparer = PreparedRequest()
 
-    def _send_internal(self, uri, method, headers=None, body=None, proxy_info=None):
-        """Do send request to target URL and validate SSL cert by default.
-        If validation failed, disable it and try again."""
+    def _send_internal(self, uri, method, headers=None, body=None):
+        """Do send request to target URL, validate SSL cert by default and return the response."""
         return self._connection.request(
             url=uri,
             data=body,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@
 #
 [tool.poetry]
 name = "cloudconnectlib"
-version = "3.1.0"
+version = "3.1.3"
 description = "APP Cloud Connect"
 authors = ["Addon Factory template <addonfactory@splunk.com>"]
 license = "APACHE-2.0"


### PR DESCRIPTION
Changes
- The old exception was not reachable even if there is an ssl error in the code execution.
- Removed that old exception from ssl lib and replaced it with SSLError exception from requests lib.
- Refactored the code a little bit in order to not raise unnecessary exceptions.

Tested the code with Add-on builder. The code flow is working as expected.